### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,24 +1,38 @@
 # Logs
-logs
 *.log
-npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
-pnpm-debug.log*
-lerna-debug.log*
+npm-debug.log
+yarn-debug.log
+yarn-error.log
+pnpm-debug.log
+lerna-debug.log
 
-node_modules
-dist
-dist-ssr
+# Dependency directories
+node_modules/
+
+# Build output
+dist/
+dist-ssr/
+
+# Local configuration files
 *.local
 
-# Editor directories and files
+# Environment variables
+.env
+.env.local
+.env.*.local
+
+# Editor and IDE files
 .vscode/*
 !.vscode/extensions.json
-.idea
+.idea/
 .DS_Store
 *.suo
 *.ntvs*
 *.njsproj
 *.sln
 *.sw?
+
+# Miscellaneous
+*.bak
+*.tmp
+coverage/


### PR DESCRIPTION
1. Simplified Logs Section:
   - Removed standalone logs since *.log covers log files. Kept specific log file names for clarity but removed redundant wildcards (e.g., npm-debug.log* → npm-debug.log).

2. Trailing Slashes:
   - Added / to directories (e.g., node_modules/, dist/) for consistency and readability, though it’s optional in .gitignore.

3. Added Environment Files:
   - Included .env and related patterns (e.g., .env.local, .env.*.local) to ignore environment variable files, which often contain sensitive data.

4. Added Common Ignores:
   - coverage/: Ignores test coverage reports (e.g., from Jest or other tools).
   - *.bak and *.tmp: Ignores backup and temporary files.

5. Kept Editor Exceptions:
   - Left !.vscode/extensions.json as-is since it’s a useful exception for sharing recommended VS Code extensions.